### PR TITLE
adding new empty state and move saved cards and number to seperated comp

### DIFF
--- a/src/components/SavedNumbers.tsx
+++ b/src/components/SavedNumbers.tsx
@@ -1,0 +1,93 @@
+// src/components/SavedNumbers.tsx
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import NumberCard from "./NumberCard";
+
+interface LottoNumbers {
+  numbers: number[];
+  strongNumber: number;
+  date: string;
+  isPredicted?: boolean;
+}
+
+interface SavedNumbersProps {
+  savedDraws: LottoNumbers[];
+}
+
+const SavedNumbers: React.FC<SavedNumbersProps> = ({ savedDraws }) => {
+  if (!savedDraws.length) {
+    return (
+      <View style={styles.savedContainer}>
+        <Text style={styles.dateText}>אין מספרים שמורים</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.savedContainer}>
+      <Text style={styles.savedTitle}>מספרים שמורים</Text>
+      {savedDraws.map((entry, index) => (
+        <View key={index} style={styles.savedEntry}>
+          <Text style={styles.dateText}>
+            {entry.isPredicted ? "חיזוי - " : ""}
+            {entry.date}
+          </Text>
+          <View style={styles.savedNumbers}>
+            {entry.numbers.map((num, numIndex) => (
+              <NumberCard
+                key={numIndex}
+                number={num}
+                isStrong={false}
+                index={numIndex}
+                isPredicted={entry.isPredicted}
+              />
+            ))}
+            <NumberCard
+              number={entry.strongNumber}
+              isStrong
+              index={entry.numbers.length}
+              isPredicted={entry.isPredicted}
+            />
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  savedNumbers: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "center",
+  },
+  savedEntry: {
+    backgroundColor: "white",
+    padding: 15,
+    borderRadius: 10,
+    marginBottom: 10,
+    shadowColor: "#000",
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+  },
+  savedTitle: {
+    fontSize: 20,
+    fontWeight: "bold",
+    marginBottom: 10,
+    color: "#333",
+    textAlign: "right",
+  },
+  savedContainer: {
+    flex: 1,
+  },
+  dateText: {
+    fontSize: 16,
+    color: "#666",
+    marginBottom: 10,
+    textAlign: "right",
+  },
+});
+
+export default SavedNumbers;

--- a/src/components/emptyState.tsx
+++ b/src/components/emptyState.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+
+const EmptyState: React.FC = () => (
+  <View style={styles.container}>
+    <MaterialIcons
+      name="info-outline"
+      size={48}
+      color="#bbb"
+      style={styles.icon}
+    />
+    <Text style={styles.text}>אין מידע שמור</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 32,
+  },
+  icon: {
+    marginBottom: 12,
+  },
+  text: {
+    fontSize: 20,
+    color: "#888",
+    textAlign: "center",
+    fontWeight: "500",
+  },
+});
+
+export default EmptyState;

--- a/src/components/savedChance.tsx
+++ b/src/components/savedChance.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import Card from "./Card";
+import EmptyState from "./emptyState";
+
+interface ChanceDraw {
+  hearts: string;
+  diamonds: string;
+  clubs: string;
+  spades: string;
+  date: string;
+  isPredicted?: boolean;
+}
+
+interface SavedChanceProps {
+  savedChances: ChanceDraw[];
+}
+
+const SavedChance: React.FC<SavedChanceProps> = ({ savedChances }) => {
+  if (!savedChances.length) {
+    return <EmptyState />;
+  }
+
+  return (
+    <View style={styles.savedContainer}>
+      <Text style={styles.savedTitle}>קלפים שמורים</Text>
+      {savedChances.map((entry, index) => (
+        <View key={index} style={styles.savedEntry}>
+          <Text style={styles.dateText}>
+            {entry.isPredicted ? "חיזוי - " : ""}
+            {entry.date}
+          </Text>
+          <View style={styles.savedCards}>
+            <Card
+              suit="♥"
+              value={entry.hearts}
+              index={0}
+              isPredicted={entry.isPredicted}
+            />
+            <Card
+              suit="♦"
+              value={entry.diamonds}
+              index={1}
+              isPredicted={entry.isPredicted}
+            />
+            <Card
+              suit="♣"
+              value={entry.clubs}
+              index={2}
+              isPredicted={entry.isPredicted}
+            />
+            <Card
+              suit="♠"
+              value={entry.spades}
+              index={3}
+              isPredicted={entry.isPredicted}
+            />
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  savedContainer: {
+    flex: 1,
+  },
+  savedTitle: {
+    fontSize: 20,
+    fontWeight: "bold",
+    marginBottom: 10,
+    color: "#333",
+    textAlign: "right",
+  },
+  savedEntry: {
+    backgroundColor: "white",
+    padding: 15,
+    borderRadius: 10,
+    marginBottom: 10,
+    shadowColor: "#000",
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+    elevation: 5,
+  },
+  dateText: {
+    fontSize: 16,
+    color: "#666",
+    marginBottom: 10,
+    textAlign: "right",
+  },
+  savedCards: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "center",
+  },
+});
+
+export default SavedChance;

--- a/src/screens/ChanceScreen.tsx
+++ b/src/screens/ChanceScreen.tsx
@@ -17,7 +17,9 @@ import { useFocusEffect } from "@react-navigation/native";
 import ScreenWithAd from "../components/ScreenWithAd";
 import AdBanner from "../components/AdBanner";
 import moment from "moment";
-
+import Constants from "expo-constants";
+import EmptyState from "../components/emptyState";
+import SavedChance from "../components/savedChance";
 interface ChanceDraw {
   hearts: string;
   diamonds: string;
@@ -161,8 +163,15 @@ const ChanceScreen: React.FC = () => {
           </View>
 
           <ScrollView style={styles.savedContainer}>
-            <AdBanner />
-            <Text style={styles.savedTitle}>קלפים שמורים</Text>
+            {Platform.OS !== "web" && Constants.appOwnership !== "expo" && (
+              <AdBanner />
+            )}
+            {savedDraws.length > 0 ? (
+              <SavedChance savedChances={savedDraws} />
+            ) : (
+              <EmptyState />
+            )}
+            {/* <Text style={styles.savedTitle}>קלפים שמורים</Text>
             {savedDraws.map((entry, index) => (
               <View key={index} style={styles.savedEntry}>
                 <Text style={styles.dateText}>
@@ -196,7 +205,7 @@ const ChanceScreen: React.FC = () => {
                   />
                 </View>
               </View>
-            ))}
+            ))} */}
           </ScrollView>
         </View>
       </View>

--- a/src/screens/LottoScreen.tsx
+++ b/src/screens/LottoScreen.tsx
@@ -16,7 +16,9 @@ import { useFocusEffect } from "@react-navigation/native";
 import moment from "moment";
 import ScreenWithAd from "../components/ScreenWithAd";
 import AdBanner from "../components/AdBanner";
-
+import Constants from "expo-constants";
+import SavedNumbers from "../components/SavedNumbers";
+import EmptyState from "../components/emptyState";
 interface LottoNumbers {
   numbers: number[];
   strongNumber: number;
@@ -107,14 +109,15 @@ const LottoScreen: React.FC = () => {
       Alert.alert("שגיאה", "שגיאה בשמירת המספרים");
     }
   };
-
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
         <View style={styles.header}>
           <Text style={styles.title}>משחק לוטו</Text>
         </View>
-        <AdBanner />
+        {Platform.OS !== "web" && Constants.appOwnership !== "expo" && (
+          <AdBanner />
+        )}
         <ScrollView style={styles.content}>
           <View style={styles.numbersContainer}>
             {currentDraw && (
@@ -163,35 +166,11 @@ const LottoScreen: React.FC = () => {
             </Button>
           </View>
 
-          <View style={styles.savedContainer}>
-            <Text style={styles.savedTitle}>מספרים שמורים</Text>
-            {savedDraws.map((entry, index) => (
-              <View key={index} style={styles.savedEntry}>
-                <Text style={styles.dateText}>
-                  {entry.isPredicted ? "חיזוי - " : ""}
-                  {/* moment().format('LLLL') */}
-                  {entry.date}
-                </Text>
-                <View style={styles.savedNumbers}>
-                  {entry.numbers.map((num, numIndex) => (
-                    <NumberCard
-                      key={numIndex}
-                      number={num}
-                      isStrong={false}
-                      index={numIndex}
-                      isPredicted={entry.isPredicted}
-                    />
-                  ))}
-                  <NumberCard
-                    number={entry.strongNumber}
-                    isStrong
-                    index={entry.numbers.length}
-                    isPredicted={entry.isPredicted}
-                  />
-                </View>
-              </View>
-            ))}
-          </View>
+          {savedDraws.length > 0 ? (
+            <SavedNumbers savedDraws={savedDraws} />
+          ) : (
+            <EmptyState />
+          )}
         </ScrollView>
       </View>
     </SafeAreaView>


### PR DESCRIPTION
## Summary
Added three reusable UI components to improve the display and management of saved results and empty states in the app: `SavedNumbers`, `SavedChance`, and `EmptyState`.

## Changes Made
- **Created `SavedNumbers` component**
  - Displays a list of saved Lotto draws with date, numbers, and prediction status.
  - Handles empty state gracefully.
- **Created `SavedChance` component**
  - Displays a list of saved Chance card draws with date, card values, and prediction status.
  - Handles empty state gracefully.
- **Created `EmptyState` component**
  - Provides a consistent, styled message for when there is no saved data to display.
  - Used in both Lotto and Chance screens for improved UX.

## Motivation
- Improve code modularity and reusability by separating saved results and empty state logic into dedicated components.
- Enhance user experience with a consistent and visually appealing empty state.
- Make it easier to maintain and extend saved results displays in the future.

## Testing
- Verified that both Lotto and Chance screens display the correct saved results using the new components.
- Confirmed that the empty state appears when there are no saved results.
- Checked that UI updates correctly when new results are added or removed.

## Related Issues
- Refactors and cleans up code for saved results display (no specific issue/ticket linked).