### PR TITLE
feat: add delete (trash icon) functionality to SavedNumbers and savedChance

### DIFF
--- a/src/components/SavedNumbers.tsx
+++ b/src/components/SavedNumbers.tsx
@@ -1,6 +1,7 @@
 // src/components/SavedNumbers.tsx
 import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import { View, Text, StyleSheet, TouchableOpacity, Alert } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import NumberCard from "./NumberCard";
 
 interface LottoNumbers {
@@ -12,9 +13,28 @@ interface LottoNumbers {
 
 interface SavedNumbersProps {
   savedDraws: LottoNumbers[];
+  onDelete?: (index: number) => void;
 }
 
-const SavedNumbers: React.FC<SavedNumbersProps> = ({ savedDraws }) => {
+const SavedNumbers: React.FC<SavedNumbersProps> = ({ savedDraws, onDelete }) => {
+  const handleDelete = (index: number) => {
+    Alert.alert(
+      "מחיקת מספרים",
+      "האם אתה בטוח שברצונך למחוק את המספרים השמורים?",
+      [
+        {
+          text: "ביטול",
+          style: "cancel",
+        },
+        {
+          text: "מחק",
+          style: "destructive",
+          onPress: () => onDelete?.(index),
+        },
+      ]
+    );
+  };
+
   if (!savedDraws.length) {
     return (
       <View style={styles.savedContainer}>
@@ -27,11 +47,21 @@ const SavedNumbers: React.FC<SavedNumbersProps> = ({ savedDraws }) => {
     <View style={styles.savedContainer}>
       <Text style={styles.savedTitle}>מספרים שמורים</Text>
       {savedDraws.map((entry, index) => (
-        <View key={index} style={styles.savedEntry}>
-          <Text style={styles.dateText}>
-            {entry.isPredicted ? "חיזוי - " : ""}
-            {entry.date}
-          </Text>
+        <View key={entry.date + entry.strongNumber} style={styles.savedEntry}>
+          <View style={styles.entryHeader}>
+            <Text style={styles.dateText}>
+              {entry.isPredicted ? "חיזוי - " : ""}
+              {entry.date}
+            </Text>
+            {onDelete && (
+              <TouchableOpacity
+                style={styles.deleteButton}
+                onPress={() => handleDelete(index)}
+              >
+                <Ionicons name="trash-outline" size={20} color="#ff4444"  style={{ marginBottom: 2, marginLeft: 10 }}/>
+              </TouchableOpacity>
+            )}
+          </View>
           <View style={styles.savedNumbers}>
             {entry.numbers.map((num, numIndex) => (
               <NumberCard
@@ -71,6 +101,19 @@ const styles = StyleSheet.create({
       width: 0,
       height: 2,
     },
+    shadowOpacity: 0.1,
+    shadowRadius: 3.84,
+    elevation: 5,
+  },
+  entryHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  deleteButton: {
+    padding: 5,
+
   },
   savedTitle: {
     fontSize: 20,
@@ -85,8 +128,8 @@ const styles = StyleSheet.create({
   dateText: {
     fontSize: 16,
     color: "#666",
-    marginBottom: 10,
     textAlign: "right",
+    flex: 1,
   },
 });
 

--- a/src/components/savedChance.tsx
+++ b/src/components/savedChance.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import { View, Text, StyleSheet, Alert, TouchableOpacity } from "react-native";
 import Card from "./Card";
 import EmptyState from "./emptyState";
+import { Ionicons } from "@expo/vector-icons";
 
 interface ChanceDraw {
   hearts: string;
@@ -14,22 +15,50 @@ interface ChanceDraw {
 
 interface SavedChanceProps {
   savedChances: ChanceDraw[];
+  onDelete?: (index: number) => void;
 }
 
-const SavedChance: React.FC<SavedChanceProps> = ({ savedChances }) => {
+const SavedChance: React.FC<SavedChanceProps> = ({ savedChances, onDelete }) => {
   if (!savedChances.length) {
     return <EmptyState />;
   }
+  const handleDelete = (index: number) => {
+    Alert.alert(
+      "מחיקת מספרים",
+      "האם אתה בטוח שברצונך למחוק את המספרים השמורים?",
+      [
+        {
+          text: "ביטול",
+          style: "cancel",
+        },
+        {
+          text: "מחק",
+          style: "destructive",
+          onPress: () => onDelete?.(index),
+        },
+      ]
+    );
+  };
 
   return (
     <View style={styles.savedContainer}>
       <Text style={styles.savedTitle}>קלפים שמורים</Text>
       {savedChances.map((entry, index) => (
         <View key={index} style={styles.savedEntry}>
+          <Text style={styles.entryHeader}>
           <Text style={styles.dateText}>
             {entry.isPredicted ? "חיזוי - " : ""}
             {entry.date}
           </Text>
+          {onDelete && (
+              <TouchableOpacity
+                style={styles.deleteButton}
+                onPress={() => handleDelete(index)}
+              >
+                <Ionicons name="trash-outline" size={20} color="#ff4444"  style={{ marginBottom: -6, marginLeft: 5 }} />
+              </TouchableOpacity>
+            )}
+            </Text>
           <View style={styles.savedCards}>
             <Card
               suit="♥"
@@ -97,6 +126,16 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     flexWrap: "wrap",
     justifyContent: "center",
+  },
+  entryHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  deleteButton: {
+    padding: 1,
+    marginBottom: -10,
   },
 });
 


### PR DESCRIPTION
## Feature: Delete Saved Numbers & Saved Chance Entries

### Summary

- Adds a trash icon to each saved numbers and saved chance entry.
- Allows users to delete individual entries with a confirmation dialog.
- Improves icon alignment for better visual consistency.

---

### Details

- **UI:** Trash icon (`Ionicons`) appears next to each entry.
- **UX:** Tapping the icon opens a confirmation dialog (in Hebrew).
- **Props:** New `onDelete` prop for both `SavedNumbers` and `savedChance` components.
- **Styling:** Icon alignment and touch target improved for RTL and accessibility.

---

### How to Test

1. Go to the screen with saved numbers or saved chance entries.
2. Tap the trash icon next to an entry.
3. Confirm deletion in the dialog.
4. Entry should be removed from the list.

---

### Checklist

- [x] Trash icon appears for each entry
- [x] Confirmation dialog prevents accidental deletion
- [x] Icon is visually aligned with text
- [x] No breaking changes to parent components

---

Closes #<issue-number-if-applicable>