### PR TITLE
feat: let users add and save their own Lotto/Chance combinations

### DIFF
--- a/src/components/ManualChanceModal.tsx
+++ b/src/components/ManualChanceModal.tsx
@@ -1,0 +1,230 @@
+import React, { useState } from "react";
+import {
+  Modal,
+  View,
+  StyleSheet,
+  Dimensions,
+  Text as RNText,
+  TouchableOpacity,
+  ScrollView,
+} from "react-native";
+import { Button, Surface } from "react-native-paper";
+
+export interface ManualChancePick {
+  hearts: string;
+  diamonds: string;
+  clubs: string;
+  spades: string;
+}
+
+interface ManualChanceModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSave: (pick: ManualChancePick) => void;
+}
+
+const CARD_VALUES = ["7", "8", "9", "10", "J", "Q", "K", "A"];
+
+type SuitKey = keyof ManualChancePick;
+
+const SUITS: { key: SuitKey; symbol: string; isRed: boolean }[] = [
+  { key: "hearts", symbol: "♥", isRed: true },
+  { key: "diamonds", symbol: "♦", isRed: true },
+  { key: "clubs", symbol: "♣", isRed: false },
+  { key: "spades", symbol: "♠", isRed: false },
+];
+
+const ManualChanceModal: React.FC<ManualChanceModalProps> = ({
+  visible,
+  onClose,
+  onSave,
+}) => {
+  const [picks, setPicks] = useState<Partial<ManualChancePick>>({});
+
+  const setPick = (suit: SuitKey, value: string) => {
+    setPicks((prev) => ({
+      ...prev,
+      [suit]: prev[suit] === value ? undefined : value,
+    }));
+  };
+
+  const reset = () => setPicks({});
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const isComplete = SUITS.every(({ key }) => picks[key]);
+
+  const handleSave = () => {
+    if (!isComplete) return;
+    onSave(picks as ManualChancePick);
+    reset();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={handleClose}
+    >
+      <View style={styles.modalOverlay}>
+        <Surface style={styles.modalContent}>
+          <View style={styles.header}>
+            <RNText style={styles.title}>הקלפים שלי</RNText>
+            <Button
+              mode="text"
+              onPress={handleClose}
+              icon="close"
+              textColor="#333"
+            >
+              סגור
+            </Button>
+          </View>
+
+          <ScrollView>
+            {SUITS.map(({ key, symbol, isRed }) => (
+              <View key={key}>
+                <RNText style={styles.sectionTitle}>
+                  <RNText style={isRed ? styles.redSuit : styles.blackSuit}>
+                    {symbol}
+                  </RNText>{" "}
+                  בחר קלף
+                </RNText>
+                <View style={styles.valuesRow}>
+                  {CARD_VALUES.map((value) => {
+                    const isSelected = picks[key] === value;
+                    return (
+                      <TouchableOpacity
+                        key={value}
+                        style={[styles.valueCell, isSelected && styles.valueCellSelected]}
+                        onPress={() => setPick(key, value)}
+                      >
+                        <RNText
+                          style={[
+                            styles.valueText,
+                            isRed && styles.redSuit,
+                            isSelected && styles.valueTextSelected,
+                          ]}
+                        >
+                          {value}
+                        </RNText>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+              </View>
+            ))}
+          </ScrollView>
+
+          <View style={styles.buttonContainer}>
+            <Button
+              mode="outlined"
+              onPress={handleSave}
+              disabled={!isComplete}
+              style={styles.saveButton}
+              icon="content-save"
+              labelStyle={styles.buttonText}
+              textColor="#333"
+            >
+              שמור קלפים
+            </Button>
+          </View>
+        </Surface>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  modalContent: {
+    backgroundColor: "white",
+    borderRadius: 20,
+    padding: 20,
+    width: Dimensions.get("window").width * 0.9,
+    maxWidth: 400,
+    maxHeight: Dimensions.get("window").height * 0.85,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  title: {
+    color: "#333",
+    textAlign: "center",
+    flex: 1,
+    fontSize: 24,
+    fontWeight: "bold",
+  },
+  sectionTitle: {
+    color: "#666",
+    marginTop: 15,
+    marginBottom: 10,
+    textAlign: "right",
+    fontSize: 18,
+    fontWeight: "500",
+  },
+  redSuit: {
+    color: "#d32f2f",
+    fontSize: 20,
+  },
+  blackSuit: {
+    color: "#333",
+    fontSize: 20,
+  },
+  valuesRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    gap: 8,
+  },
+  valueCell: {
+    width: 38,
+    height: 50,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: "#ccc",
+    backgroundColor: "white",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  valueCellSelected: {
+    backgroundColor: "#2196F3",
+    borderColor: "#2196F3",
+  },
+  valueText: {
+    fontSize: 16,
+    fontWeight: "bold",
+    color: "#333",
+  },
+  valueTextSelected: {
+    color: "white",
+  },
+  buttonContainer: {
+    marginTop: 20,
+    width: "100%",
+    paddingHorizontal: 10,
+  },
+  saveButton: {
+    width: "100%",
+    borderColor: "rgba(156, 39, 176, 0.6)",
+    borderWidth: 2,
+    paddingVertical: 8,
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+});
+
+export default ManualChanceModal;

--- a/src/components/ManualLottoModal.tsx
+++ b/src/components/ManualLottoModal.tsx
@@ -1,0 +1,226 @@
+import React, { useState } from "react";
+import {
+  Modal,
+  View,
+  StyleSheet,
+  Dimensions,
+  Text as RNText,
+  TouchableOpacity,
+  ScrollView,
+} from "react-native";
+import { Button, Surface } from "react-native-paper";
+
+interface ManualLottoModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSave: (numbers: number[], strongNumber: number) => void;
+}
+
+const MAIN_NUMBERS = Array.from({ length: 37 }, (_, i) => i + 1);
+const STRONG_NUMBERS = Array.from({ length: 7 }, (_, i) => i + 1);
+const MAX_MAIN = 6;
+
+const ManualLottoModal: React.FC<ManualLottoModalProps> = ({
+  visible,
+  onClose,
+  onSave,
+}) => {
+  const [selected, setSelected] = useState<number[]>([]);
+  const [strong, setStrong] = useState<number | null>(null);
+
+  const toggleNumber = (num: number) => {
+    setSelected((prev) => {
+      if (prev.includes(num)) return prev.filter((n) => n !== num);
+      if (prev.length >= MAX_MAIN) return prev;
+      return [...prev, num];
+    });
+  };
+
+  const reset = () => {
+    setSelected([]);
+    setStrong(null);
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const handleSave = () => {
+    if (selected.length !== MAX_MAIN || strong === null) return;
+    onSave([...selected].sort((a, b) => a - b), strong);
+    reset();
+  };
+
+  const isValidPick = selected.length === MAX_MAIN && strong !== null;
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={handleClose}
+    >
+      <View style={styles.modalOverlay}>
+        <Surface style={styles.modalContent}>
+          <View style={styles.header}>
+            <RNText style={styles.title}>המספרים שלי</RNText>
+            <Button
+              mode="text"
+              onPress={handleClose}
+              icon="close"
+              textColor="#333"
+            >
+              סגור
+            </Button>
+          </View>
+
+          <ScrollView>
+            <RNText style={styles.sectionTitle}>
+              בחר 6 מספרים ({selected.length}/{MAX_MAIN})
+            </RNText>
+            <View style={styles.numbersGrid}>
+              {MAIN_NUMBERS.map((num) => {
+                const isSelected = selected.includes(num);
+                return (
+                  <TouchableOpacity
+                    key={num}
+                    style={[styles.numberCell, isSelected && styles.numberCellSelected]}
+                    onPress={() => toggleNumber(num)}
+                  >
+                    <RNText
+                      style={[styles.numberCellText, isSelected && styles.numberCellTextSelected]}
+                    >
+                      {num}
+                    </RNText>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+
+            <RNText style={styles.sectionTitle}>בחר מספר חזק</RNText>
+            <View style={styles.numbersGrid}>
+              {STRONG_NUMBERS.map((num) => {
+                const isSelected = strong === num;
+                return (
+                  <TouchableOpacity
+                    key={num}
+                    style={[styles.numberCell, isSelected && styles.strongCellSelected]}
+                    onPress={() => setStrong(isSelected ? null : num)}
+                  >
+                    <RNText
+                      style={[styles.numberCellText, isSelected && styles.numberCellTextSelected]}
+                    >
+                      {num}
+                    </RNText>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+          </ScrollView>
+
+          <View style={styles.buttonContainer}>
+            <Button
+              mode="outlined"
+              onPress={handleSave}
+              disabled={!isValidPick}
+              style={styles.saveButton}
+              icon="content-save"
+              labelStyle={styles.buttonText}
+              textColor="#333"
+            >
+              שמור מספרים
+            </Button>
+          </View>
+        </Surface>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  modalContent: {
+    backgroundColor: "white",
+    borderRadius: 20,
+    padding: 20,
+    width: Dimensions.get("window").width * 0.9,
+    maxWidth: 400,
+    maxHeight: Dimensions.get("window").height * 0.85,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  title: {
+    color: "#333",
+    textAlign: "center",
+    flex: 1,
+    fontSize: 24,
+    fontWeight: "bold",
+  },
+  sectionTitle: {
+    color: "#666",
+    marginTop: 15,
+    marginBottom: 10,
+    textAlign: "right",
+    fontSize: 18,
+    fontWeight: "500",
+  },
+  numbersGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    gap: 8,
+  },
+  numberCell: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    borderWidth: 1,
+    borderColor: "#ccc",
+    backgroundColor: "white",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  numberCellSelected: {
+    backgroundColor: "#2196F3",
+    borderColor: "#2196F3",
+  },
+  strongCellSelected: {
+    backgroundColor: "#FF5722",
+    borderColor: "#FF5722",
+  },
+  numberCellText: {
+    fontSize: 16,
+    fontWeight: "bold",
+    color: "#333",
+  },
+  numberCellTextSelected: {
+    color: "white",
+  },
+  buttonContainer: {
+    marginTop: 20,
+    width: "100%",
+    paddingHorizontal: 10,
+  },
+  saveButton: {
+    width: "100%",
+    borderColor: "rgba(156, 39, 176, 0.6)",
+    borderWidth: 2,
+    paddingVertical: 8,
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+});
+
+export default ManualLottoModal;

--- a/src/components/SavedNumbers.tsx
+++ b/src/components/SavedNumbers.tsx
@@ -10,7 +10,15 @@ interface LottoNumbers {
   date: string;
   isPredicted?: boolean;
   uniqueId?: string;
+  id?: string;
+  source?: "generated" | "prediction" | "manual";
 }
+
+const sourceLabel = (entry: LottoNumbers): string => {
+  if (entry.source === "manual") return "המספרים שלי - ";
+  if (entry.source === "prediction" || entry.isPredicted) return "חיזוי - ";
+  return "";
+};
 
 interface SavedNumbersProps {
   savedDraws: LottoNumbers[];
@@ -52,12 +60,16 @@ const SavedNumbers: React.FC<SavedNumbersProps> = ({
       <Text style={styles.savedTitle}>מספרים שמורים</Text>
       {savedDraws.map((entry, index) => (
         <View
-          key={entry.uniqueId || `${entry.date}_${entry.strongNumber}_${index}`}
+          key={
+            entry.id ||
+            entry.uniqueId ||
+            `${entry.date}_${entry.strongNumber}_${index}`
+          }
           style={styles.savedEntry}
         >
           <View style={styles.entryHeader}>
             <Text style={styles.dateText}>
-              {entry.isPredicted ? "חיזוי - " : ""}
+              {sourceLabel(entry)}
               {entry.date}
             </Text>
             {onDelete && (
@@ -81,14 +93,14 @@ const SavedNumbers: React.FC<SavedNumbersProps> = ({
                 number={num}
                 isStrong={false}
                 index={numIndex}
-                isPredicted={entry.isPredicted}
+                isPredicted={entry.isPredicted || entry.source === "prediction"}
               />
             ))}
             <NumberCard
               number={entry.strongNumber}
               isStrong
               index={entry.numbers.length}
-              isPredicted={entry.isPredicted}
+              isPredicted={entry.isPredicted || entry.source === "prediction"}
             />
           </View>
         </View>

--- a/src/components/savedChance.tsx
+++ b/src/components/savedChance.tsx
@@ -11,7 +11,15 @@ interface ChanceDraw {
   spades: string;
   date: string;
   isPredicted?: boolean;
+  id?: string;
+  source?: "generated" | "prediction" | "manual";
 }
+
+const sourceLabel = (entry: ChanceDraw): string => {
+  if (entry.source === "manual") return "הקלפים שלי - ";
+  if (entry.source === "prediction" || entry.isPredicted) return "חיזוי - ";
+  return "";
+};
 
 interface SavedChanceProps {
   savedChances: ChanceDraw[];
@@ -47,10 +55,10 @@ const SavedChance: React.FC<SavedChanceProps> = ({
     <View style={styles.savedContainer}>
       <Text style={styles.savedTitle}>קלפים שמורים</Text>
       {savedChances.map((entry, index) => (
-        <View key={index} style={styles.savedEntry}>
+        <View key={entry.id || index} style={styles.savedEntry}>
           <View style={styles.entryHeader}>
             <Text style={styles.dateText}>
-              {entry.isPredicted ? "חיזוי - " : ""}
+              {sourceLabel(entry)}
               {entry.date}
             </Text>
             {onDelete && (
@@ -72,25 +80,25 @@ const SavedChance: React.FC<SavedChanceProps> = ({
               suit="♥"
               value={entry.hearts}
               index={0}
-              isPredicted={entry.isPredicted}
+              isPredicted={entry.isPredicted || entry.source === "prediction"}
             />
             <Card
               suit="♦"
               value={entry.diamonds}
               index={1}
-              isPredicted={entry.isPredicted}
+              isPredicted={entry.isPredicted || entry.source === "prediction"}
             />
             <Card
               suit="♣"
               value={entry.clubs}
               index={2}
-              isPredicted={entry.isPredicted}
+              isPredicted={entry.isPredicted || entry.source === "prediction"}
             />
             <Card
               suit="♠"
               value={entry.spades}
               index={3}
-              isPredicted={entry.isPredicted}
+              isPredicted={entry.isPredicted || entry.source === "prediction"}
             />
           </View>
         </View>

--- a/src/screens/ChanceScreen.tsx
+++ b/src/screens/ChanceScreen.tsx
@@ -8,112 +8,50 @@ import {
   SafeAreaView,
   Platform,
 } from "react-native";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Card from "../components/Card";
 import SavedChance from "../components/savedChance";
 import { Button } from "react-native-paper";
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
-import { format, parse, isValid, getTime, parseISO } from "date-fns";
-import ScreenWithAd from "../components/ScreenWithAd";
 import AdBanner from "../components/AdBanner";
-import Constants from "expo-constants";
 import EmptyState from "../components/emptyState";
 import { generateChanceDraw } from "../utils/generators";
-interface ChanceDraw {
+import ManualChanceModal, {
+  ManualChancePick,
+} from "../components/ManualChanceModal";
+import {
+  SavedChanceItem,
+  loadSavedChance,
+  addSavedChance,
+  deleteSavedChance,
+} from "../utils/savedStorage";
+
+interface CurrentChanceDraw {
   hearts: string;
   diamonds: string;
   clubs: string;
   spades: string;
   date: string;
-  isPredicted?: boolean;
 }
 
-const CARD_VALUES = ["7", "8", "9", "10", "J", "Q", "K", "A"];
-const SUITS = ["♥", "♦", "♣", "♠"] as const;
-
 const ChanceScreen: React.FC = () => {
-  const [currentDraw, setCurrentDraw] = useState<ChanceDraw | null>(null);
-  const [savedDraws, setSavedDraws] = useState<ChanceDraw[]>([]);
+  const [currentDraw, setCurrentDraw] = useState<CurrentChanceDraw | null>(
+    null
+  );
+  const [savedDraws, setSavedDraws] = useState<SavedChanceItem[]>([]);
+  const [manualModalVisible, setManualModalVisible] = useState(false);
   const insets = useSafeAreaInsets();
 
   useFocusEffect(
     React.useCallback(() => {
-      loadSavedDraws();
+      loadSavedChance()
+        .then(setSavedDraws)
+        .catch((error) => console.error("Error loading saved draws:", error));
     }, [])
   );
 
-  const loadSavedDraws = async () => {
-    try {
-      // Load regular saved draws
-      const saved = await AsyncStorage.getItem("chanceDraws");
-      const regularSaved = saved ? JSON.parse(saved) : [];
-
-      // Load predicted draws
-      const savedPredictions = await AsyncStorage.getItem(
-        "savedChancePredictions"
-      );
-      const predictedSaved = savedPredictions
-        ? JSON.parse(savedPredictions)
-        : [];
-
-      // Combine both types of saved draws
-      const allSaved = [
-        ...regularSaved,
-        ...predictedSaved.map((pred: any) => ({
-          hearts: pred.hearts.toString(),
-          diamonds: pred.diamonds.toString(),
-          clubs: pred.clubs.toString(),
-          spades: pred.spades.toString(),
-          date: (() => {
-            try {
-              let parsedDate = parseISO(pred.date);
-              if (!isValid(parsedDate)) {
-                parsedDate = new Date(pred.date);
-              }
-              return isValid(parsedDate)
-                ? format(parsedDate, "dd/MM/yyyy HH:mm")
-                : "תאריך לא תקין";
-            } catch {
-              return "תאריך לא תקין";
-            }
-          })(),
-          isPredicted: true,
-        })),
-      ].sort((a, b) => {
-        const dateA = parse(a.date, "dd/MM/yyyy HH:mm", new Date());
-        const dateB = parse(b.date, "dd/MM/yyyy HH:mm", new Date());
-
-        if (isValid(dateA) && isValid(dateB)) {
-          return getTime(dateB) - getTime(dateA);
-        }
-        if (!isValid(dateA) && isValid(dateB)) return 1;
-        if (isValid(dateA) && !isValid(dateB)) return -1;
-        return 0;
-      });
-
-      setSavedDraws(allSaved);
-    } catch (error) {
-      console.error("Error loading saved draws:", error);
-    }
-  };
-
   const drawCard = () => {
-    // const newDraw: ChanceDraw = {
-    //   hearts: CARD_VALUES[Math.floor(Math.random() * CARD_VALUES.length)],
-    //   diamonds: CARD_VALUES[Math.floor(Math.random() * CARD_VALUES.length)],
-    //   clubs: CARD_VALUES[Math.floor(Math.random() * CARD_VALUES.length)],
-    //   spades: CARD_VALUES[Math.floor(Math.random() * CARD_VALUES.length)],
-    //   date: new Date().toLocaleString("he-IL", {
-    //     year: "numeric",
-    //     month: "2-digit",
-    //     day: "2-digit",
-    //     hour: "2-digit",
-    //     minute: "2-digit",
-    //     hour12: false,
-    //   }),
-    // };
     setCurrentDraw(generateChanceDraw());
   };
 
@@ -124,20 +62,42 @@ const ChanceScreen: React.FC = () => {
     }
 
     try {
-      const updatedSaved = [...savedDraws, currentDraw];
-      await AsyncStorage.setItem("chanceDraws", JSON.stringify(updatedSaved));
-      setSavedDraws(updatedSaved);
+      const updated = await addSavedChance({
+        hearts: currentDraw.hearts,
+        diamonds: currentDraw.diamonds,
+        clubs: currentDraw.clubs,
+        spades: currentDraw.spades,
+        source: "generated",
+      });
+      setSavedDraws(updated);
       Alert.alert("הצלחה", "הקלפים נשמרו בהצלחה!");
     } catch (error) {
       console.error("Error saving draw:", error);
       Alert.alert("שגיאה", "שגיאה בשמירת הקלפים");
     }
   };
+
+  const saveManualDraw = async (pick: ManualChancePick) => {
+    try {
+      const updated = await addSavedChance({
+        ...pick,
+        source: "manual",
+      });
+      setSavedDraws(updated);
+      setManualModalVisible(false);
+      Alert.alert("הצלחה", "הקלפים שלך נשמרו בהצלחה!");
+    } catch (error) {
+      console.error("Error saving manual draw:", error);
+      Alert.alert("שגיאה", "שגיאה בשמירת הקלפים");
+    }
+  };
+
   const handleDelete = async (index: number) => {
     try {
-      const updatedSaved = savedDraws.filter((_, i) => i !== index);
-      await AsyncStorage.setItem("chanceDraws", JSON.stringify(updatedSaved));
-      setSavedDraws(updatedSaved);
+      const itemToDelete = savedDraws[index];
+      if (!itemToDelete) return;
+      const updated = await deleteSavedChance(itemToDelete.id);
+      setSavedDraws(updated);
       Alert.alert("הצלחה", "הקלפים נמחקו בהצלחה!");
     } catch (error) {
       console.error("Error deleting draw:", error);
@@ -190,6 +150,21 @@ const ChanceScreen: React.FC = () => {
             </Button>
           </View>
 
+          <View style={styles.buttonContainer}>
+            <Button
+              mode="outlined"
+              onPress={() => setManualModalVisible(true)}
+              style={styles.button}
+              icon={({ size, color }) => (
+                <Ionicons name="create-outline" size={24} color="#333" />
+              )}
+              labelStyle={styles.buttonText}
+              textColor="#333"
+            >
+              הוסף קלפים משלי
+            </Button>
+          </View>
+
           <ScrollView style={styles.savedContainer}>
             <AdBanner />
             {savedDraws.length > 0 ? (
@@ -199,6 +174,12 @@ const ChanceScreen: React.FC = () => {
             )}
           </ScrollView>
         </View>
+
+        <ManualChanceModal
+          visible={manualModalVisible}
+          onClose={() => setManualModalVisible(false)}
+          onSave={saveManualDraw}
+        />
       </View>
     </SafeAreaView>
   );
@@ -250,38 +231,6 @@ const styles = StyleSheet.create({
   },
   savedContainer: {
     flex: 1,
-  },
-  savedTitle: {
-    fontSize: 20,
-    fontWeight: "bold",
-    marginBottom: 10,
-    color: "#333",
-    textAlign: "right",
-  },
-  savedEntry: {
-    backgroundColor: "white",
-    padding: 15,
-    borderRadius: 10,
-    marginBottom: 10,
-    shadowColor: "#000",
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
-    elevation: 5,
-  },
-  dateText: {
-    fontSize: 16,
-    color: "#666",
-    marginBottom: 10,
-    textAlign: "right",
-  },
-  savedCards: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    justifyContent: "center",
   },
 });
 

--- a/src/screens/LottoScreen.tsx
+++ b/src/screens/LottoScreen.tsx
@@ -8,124 +8,44 @@ import {
   SafeAreaView,
   Platform,
 } from "react-native";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import NumberCard from "../components/NumberCard";
 import { Button } from "react-native-paper";
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
-import { format, parse, isValid, getTime, parseISO } from "date-fns";
 import ScreenWithAd from "../components/ScreenWithAd";
 import AdBanner from "../components/AdBanner";
 import Constants from "expo-constants";
 import SavedNumbers from "../components/SavedNumbers";
 import EmptyState from "../components/emptyState";
-interface LottoNumbers {
+import ManualLottoModal from "../components/ManualLottoModal";
+import {
+  SavedLottoItem,
+  loadSavedLotto,
+  addSavedLotto,
+  deleteSavedLotto,
+  nowDisplayDate,
+} from "../utils/savedStorage";
+
+interface CurrentDraw {
   numbers: number[];
   strongNumber: number;
   date: string;
-  isPredicted?: boolean;
-  uniqueId?: string;
 }
 
 const LottoScreen: React.FC = () => {
-  const [currentDraw, setCurrentDraw] = useState<LottoNumbers | null>(null);
-  const [savedDraws, setSavedDraws] = useState<LottoNumbers[]>([]);
+  const [currentDraw, setCurrentDraw] = useState<CurrentDraw | null>(null);
+  const [savedDraws, setSavedDraws] = useState<SavedLottoItem[]>([]);
+  const [manualModalVisible, setManualModalVisible] = useState(false);
   const insets = useSafeAreaInsets();
 
   useFocusEffect(
     React.useCallback(() => {
-      loadSavedDraws();
+      loadSavedLotto()
+        .then(setSavedDraws)
+        .catch((error) => console.error("Error loading saved draws:", error));
     }, [])
   );
-
-  const loadSavedDraws = async () => {
-    try {
-      // Load regular saved draws
-      const saved = await AsyncStorage.getItem("lottoDraws");
-      const regularSaved = saved ? JSON.parse(saved) : [];
-
-      // Ensure regular saved draws have uniqueId
-      const regularSavedWithIds = regularSaved.map(
-        (draw: any, index: number) => ({
-          ...draw,
-          uniqueId: draw.uniqueId || `regular_legacy_${index}_${Date.now()}`,
-        })
-      );
-
-      // Load predicted draws
-      const savedPredictions = await AsyncStorage.getItem(
-        "savedLottoPredictions"
-      );
-      const predictedSaved = savedPredictions
-        ? JSON.parse(savedPredictions)
-        : [];
-
-      // Combine both types of saved draws
-      const allSaved = [
-        ...regularSavedWithIds,
-        ...predictedSaved.map((pred: any, index: number) => {
-          // Handle different possible date formats
-          let formattedDate = "תאריך לא תקין";
-
-          if (pred.date) {
-            // Try to parse different date formats
-            let parsedDate;
-
-            // Try DD.MM.YYYY, HH:mm format
-            if (pred.date.includes(".") && pred.date.includes(",")) {
-              parsedDate = parse(pred.date, "dd.MM.yyyy, HH:mm", new Date());
-            }
-            // Try DD/MM/YYYY HH:mm format
-            else if (pred.date.includes("/")) {
-              parsedDate = parse(pred.date, "dd/MM/yyyy HH:mm", new Date());
-            }
-            // Try ISO format or other standard formats
-            else {
-              try {
-                parsedDate = parseISO(pred.date);
-                if (!isValid(parsedDate)) {
-                  parsedDate = new Date(pred.date);
-                }
-              } catch {
-                parsedDate = new Date(pred.date);
-              }
-            }
-
-            if (isValid(parsedDate)) {
-              formattedDate = format(parsedDate, "dd/MM/yyyy HH:mm");
-            }
-          }
-
-          return {
-            numbers: pred.numbers,
-            strongNumber: pred.strongNumber,
-            date: formattedDate,
-            isPredicted: true,
-            uniqueId: `predicted_${index}_${Date.now()}`, // Add unique identifier
-          };
-        }),
-      ].sort((a, b) => {
-        // Handle sorting with proper date parsing
-        const dateA = parse(a.date, "dd/MM/yyyy HH:mm", new Date());
-        const dateB = parse(b.date, "dd/MM/yyyy HH:mm", new Date());
-
-        // If both dates are valid, sort by date
-        if (isValid(dateA) && isValid(dateB)) {
-          return getTime(dateB) - getTime(dateA);
-        }
-        // Put invalid dates at the end
-        if (!isValid(dateA) && isValid(dateB)) return 1;
-        if (isValid(dateA) && !isValid(dateB)) return -1;
-        // If both invalid, maintain original order
-        return 0;
-      });
-
-      setSavedDraws(allSaved);
-    } catch (error) {
-      console.error("Error loading saved draws:", error);
-    }
-  };
 
   const generateNumbers = () => {
     const numbers = new Set<number>();
@@ -136,14 +56,7 @@ const LottoScreen: React.FC = () => {
     setCurrentDraw({
       numbers: Array.from(numbers).sort((a, b) => a - b),
       strongNumber,
-      date: new Date().toLocaleString("he-IL", {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: false,
-      }),
+      date: nowDisplayDate(),
     });
   };
 
@@ -154,13 +67,12 @@ const LottoScreen: React.FC = () => {
     }
 
     try {
-      const drawWithId = {
-        ...currentDraw,
-        uniqueId: `regular_${Date.now()}_${Math.random()}`,
-      };
-      const updatedSaved = [...savedDraws, drawWithId];
-      await AsyncStorage.setItem("lottoDraws", JSON.stringify(updatedSaved));
-      setSavedDraws(updatedSaved);
+      const updated = await addSavedLotto({
+        numbers: currentDraw.numbers,
+        strongNumber: currentDraw.strongNumber,
+        source: "generated",
+      });
+      setSavedDraws(updated);
       Alert.alert("הצלחה", "המספרים נשמרו בהצלחה!");
     } catch (error) {
       console.error("Error saving draw:", error);
@@ -168,62 +80,34 @@ const LottoScreen: React.FC = () => {
     }
   };
 
+  const saveManualDraw = async (numbers: number[], strongNumber: number) => {
+    try {
+      const updated = await addSavedLotto({
+        numbers,
+        strongNumber,
+        source: "manual",
+      });
+      setSavedDraws(updated);
+      setManualModalVisible(false);
+      Alert.alert("הצלחה", "המספרים שלך נשמרו בהצלחה!");
+    } catch (error) {
+      console.error("Error saving manual draw:", error);
+      Alert.alert("שגיאה", "שגיאה בשמירת המספרים");
+    }
+  };
+
   const handleDelete = async (index: number) => {
     try {
       const itemToDelete = savedDraws[index];
-
-      if (itemToDelete.isPredicted) {
-        // Handle predicted draws deletion
-        const savedPredictions = await AsyncStorage.getItem(
-          "savedLottoPredictions"
-        );
-        const predictedSaved = savedPredictions
-          ? JSON.parse(savedPredictions)
-          : [];
-
-        // Find and remove the prediction from storage
-        const updatedPredictions = predictedSaved.filter((pred: any) => {
-          // Match by numbers and strongNumber since we don't have original uniqueId
-          return !(
-            JSON.stringify(pred.numbers.sort()) ===
-              JSON.stringify(itemToDelete.numbers.sort()) &&
-            pred.strongNumber === itemToDelete.strongNumber
-          );
-        });
-
-        await AsyncStorage.setItem(
-          "savedLottoPredictions",
-          JSON.stringify(updatedPredictions)
-        );
-      } else {
-        // Handle regular draws deletion
-        const saved = await AsyncStorage.getItem("lottoDraws");
-        const regularSaved = saved ? JSON.parse(saved) : [];
-
-        // Filter out the deleted item from regular saved draws
-        const updatedRegularDraws = regularSaved.filter((draw: any) => {
-          return !(
-            JSON.stringify(draw.numbers.sort()) ===
-              JSON.stringify(itemToDelete.numbers.sort()) &&
-            draw.strongNumber === itemToDelete.strongNumber &&
-            draw.date === itemToDelete.date
-          );
-        });
-
-        await AsyncStorage.setItem(
-          "lottoDraws",
-          JSON.stringify(updatedRegularDraws)
-        );
-      }
-
-      // Update state by removing the item at the specified index
-      const updatedSavedDraws = savedDraws.filter((_, i) => i !== index);
-      setSavedDraws(updatedSavedDraws);
+      if (!itemToDelete) return;
+      const updated = await deleteSavedLotto(itemToDelete.id);
+      setSavedDraws(updated);
     } catch (error) {
       console.error("Error deleting draw:", error);
       Alert.alert("שגיאה", "שגיאה במחיקת המספרים");
     }
   };
+
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
@@ -281,12 +165,33 @@ const LottoScreen: React.FC = () => {
             </Button>
           </View>
 
+          <View style={styles.buttonContainer}>
+            <Button
+              mode="outlined"
+              onPress={() => setManualModalVisible(true)}
+              style={styles.button}
+              icon={({ size, color }) => (
+                <Ionicons name="create-outline" size={24} color="#333" />
+              )}
+              labelStyle={styles.buttonText}
+              textColor="#333"
+            >
+              הוסף מספרים משלי
+            </Button>
+          </View>
+
           {savedDraws.length > 0 ? (
             <SavedNumbers savedDraws={savedDraws} onDelete={handleDelete} />
           ) : (
             <EmptyState />
           )}
         </ScrollView>
+
+        <ManualLottoModal
+          visible={manualModalVisible}
+          onClose={() => setManualModalVisible(false)}
+          onSave={saveManualDraw}
+        />
       </View>
     </SafeAreaView>
   );
@@ -335,41 +240,6 @@ const styles = StyleSheet.create({
   buttonText: {
     fontSize: 16,
     fontWeight: "bold",
-  },
-  savedContainer: {
-    flex: 1,
-  },
-  savedTitle: {
-    fontSize: 20,
-    fontWeight: "bold",
-    marginBottom: 10,
-    color: "#333",
-    textAlign: "right",
-  },
-  savedEntry: {
-    backgroundColor: "white",
-    padding: 15,
-    borderRadius: 10,
-    marginBottom: 10,
-    shadowColor: "#000",
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
-    elevation: 5,
-  },
-  dateText: {
-    fontSize: 16,
-    color: "#666",
-    marginBottom: 10,
-    textAlign: "right",
-  },
-  savedNumbers: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    justifyContent: "center",
   },
 });
 

--- a/src/utils/savedStorage.ts
+++ b/src/utils/savedStorage.ts
@@ -1,0 +1,216 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { format, parse, isValid, parseISO } from "date-fns";
+
+// Unified saved-items storage.
+// One list per game, each item carries its source. Legacy keys
+// (lottoDraws / savedLottoPredictions / chanceDraws / savedChancePredictions)
+// are migrated into the unified list on every load, so screens that still
+// write to legacy keys (e.g. PredictionsScreen) keep working.
+
+export type SavedSource = "generated" | "prediction" | "manual";
+
+export interface SavedLottoItem {
+  id: string;
+  numbers: number[];
+  strongNumber: number;
+  source: SavedSource;
+  date: string; // display string dd/MM/yyyy HH:mm
+  createdAt: number; // ms epoch, for sorting
+}
+
+export interface SavedChanceItem {
+  id: string;
+  hearts: string;
+  diamonds: string;
+  clubs: string;
+  spades: string;
+  source: SavedSource;
+  date: string;
+  createdAt: number;
+}
+
+const LOTTO_KEY = "lottoSavedV2";
+const CHANCE_KEY = "chanceSavedV2";
+
+const LEGACY_LOTTO_KEY = "lottoDraws";
+const LEGACY_LOTTO_PREDICTIONS_KEY = "savedLottoPredictions";
+const LEGACY_CHANCE_KEY = "chanceDraws";
+const LEGACY_CHANCE_PREDICTIONS_KEY = "savedChancePredictions";
+
+const DISPLAY_FORMAT = "dd/MM/yyyy HH:mm";
+
+const makeId = (): string =>
+  `${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+
+export const nowDisplayDate = (): string => format(new Date(), DISPLAY_FORMAT);
+
+// Normalize the various legacy date formats to a display string + timestamp
+const normalizeDate = (raw: unknown): { date: string; createdAt: number } => {
+  if (typeof raw === "string" && raw.length > 0) {
+    const candidates = [
+      parse(raw, DISPLAY_FORMAT, new Date()),
+      parse(raw, "dd.MM.yyyy, HH:mm", new Date()),
+      parseISO(raw),
+      new Date(raw),
+    ];
+    for (const parsed of candidates) {
+      if (isValid(parsed)) {
+        return { date: format(parsed, DISPLAY_FORMAT), createdAt: parsed.getTime() };
+      }
+    }
+  }
+  return { date: "תאריך לא תקין", createdAt: 0 };
+};
+
+const readJson = async (key: string): Promise<any[]> => {
+  try {
+    const raw = await AsyncStorage.getItem(key);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const sortByNewest = <T extends { createdAt: number }>(items: T[]): T[] =>
+  [...items].sort((a, b) => b.createdAt - a.createdAt);
+
+// ---------- Lotto ----------
+
+const migrateLegacyLotto = async (): Promise<SavedLottoItem[]> => {
+  const [regular, predictions] = await Promise.all([
+    readJson(LEGACY_LOTTO_KEY),
+    readJson(LEGACY_LOTTO_PREDICTIONS_KEY),
+  ]);
+  if (!regular.length && !predictions.length) return [];
+
+  const migrated: SavedLottoItem[] = [
+    ...regular
+      .filter((d: any) => Array.isArray(d?.numbers))
+      .map((d: any) => ({
+        id: d.uniqueId || makeId(),
+        numbers: d.numbers,
+        strongNumber: d.strongNumber,
+        source: (d.isPredicted ? "prediction" : "generated") as SavedSource,
+        ...normalizeDate(d.date),
+      })),
+    ...predictions
+      .filter((p: any) => Array.isArray(p?.numbers))
+      .map((p: any) => ({
+        id: makeId(),
+        numbers: p.numbers,
+        strongNumber: p.strongNumber,
+        source: "prediction" as SavedSource,
+        ...normalizeDate(p.date),
+      })),
+  ];
+
+  await AsyncStorage.multiRemove([
+    LEGACY_LOTTO_KEY,
+    LEGACY_LOTTO_PREDICTIONS_KEY,
+  ]);
+  return migrated;
+};
+
+export const loadSavedLotto = async (): Promise<SavedLottoItem[]> => {
+  const [current, migrated] = await Promise.all([
+    readJson(LOTTO_KEY) as Promise<SavedLottoItem[]>,
+    migrateLegacyLotto(),
+  ]);
+  const all = sortByNewest([...current, ...migrated]);
+  if (migrated.length) {
+    await AsyncStorage.setItem(LOTTO_KEY, JSON.stringify(all));
+  }
+  return all;
+};
+
+export const addSavedLotto = async (
+  item: Omit<SavedLottoItem, "id" | "date" | "createdAt">
+): Promise<SavedLottoItem[]> => {
+  const current = await loadSavedLotto();
+  const newItem: SavedLottoItem = {
+    ...item,
+    id: makeId(),
+    date: nowDisplayDate(),
+    createdAt: Date.now(),
+  };
+  const updated = sortByNewest([newItem, ...current]);
+  await AsyncStorage.setItem(LOTTO_KEY, JSON.stringify(updated));
+  return updated;
+};
+
+export const deleteSavedLotto = async (
+  id: string
+): Promise<SavedLottoItem[]> => {
+  const current = await loadSavedLotto();
+  const updated = current.filter((item) => item.id !== id);
+  await AsyncStorage.setItem(LOTTO_KEY, JSON.stringify(updated));
+  return updated;
+};
+
+// ---------- Chance ----------
+
+const migrateLegacyChance = async (): Promise<SavedChanceItem[]> => {
+  const [regular, predictions] = await Promise.all([
+    readJson(LEGACY_CHANCE_KEY),
+    readJson(LEGACY_CHANCE_PREDICTIONS_KEY),
+  ]);
+  if (!regular.length && !predictions.length) return [];
+
+  const toItem = (d: any, source: SavedSource): SavedChanceItem => ({
+    id: makeId(),
+    hearts: String(d.hearts),
+    diamonds: String(d.diamonds),
+    clubs: String(d.clubs),
+    spades: String(d.spades),
+    source: d.isPredicted ? "prediction" : source,
+    ...normalizeDate(d.date),
+  });
+
+  const migrated: SavedChanceItem[] = [
+    ...regular.filter((d: any) => d?.hearts != null).map((d: any) => toItem(d, "generated")),
+    ...predictions.filter((d: any) => d?.hearts != null).map((d: any) => toItem(d, "prediction")),
+  ];
+
+  await AsyncStorage.multiRemove([
+    LEGACY_CHANCE_KEY,
+    LEGACY_CHANCE_PREDICTIONS_KEY,
+  ]);
+  return migrated;
+};
+
+export const loadSavedChance = async (): Promise<SavedChanceItem[]> => {
+  const [current, migrated] = await Promise.all([
+    readJson(CHANCE_KEY) as Promise<SavedChanceItem[]>,
+    migrateLegacyChance(),
+  ]);
+  const all = sortByNewest([...current, ...migrated]);
+  if (migrated.length) {
+    await AsyncStorage.setItem(CHANCE_KEY, JSON.stringify(all));
+  }
+  return all;
+};
+
+export const addSavedChance = async (
+  item: Omit<SavedChanceItem, "id" | "date" | "createdAt">
+): Promise<SavedChanceItem[]> => {
+  const current = await loadSavedChance();
+  const newItem: SavedChanceItem = {
+    ...item,
+    id: makeId(),
+    date: nowDisplayDate(),
+    createdAt: Date.now(),
+  };
+  const updated = sortByNewest([newItem, ...current]);
+  await AsyncStorage.setItem(CHANCE_KEY, JSON.stringify(updated));
+  return updated;
+};
+
+export const deleteSavedChance = async (
+  id: string
+): Promise<SavedChanceItem[]> => {
+  const current = await loadSavedChance();
+  const updated = current.filter((item) => item.id !== id);
+  await AsyncStorage.setItem(CHANCE_KEY, JSON.stringify(updated));
+  return updated;
+};


### PR DESCRIPTION
- ManualLottoModal: pick exactly 6 numbers (1-37) + strong number (1-7)
- ManualChanceModal: pick a card value (7-A) per suit
- "Add my own" button on Lotto and Chance screens
- Unified saved-items storage (savedStorage.ts): one list per game with source: generated | prediction | manual, sorted by createdAt, with automatic migration from the 4 legacy AsyncStorage keys on load
- Saved lists show a source badge ("המספרים שלי" / "חיזוי") and delete by stable id instead of content matching